### PR TITLE
Rename `lib3rd.h` to `lua_extensions.h`

### DIFF
--- a/src/lua.hpp
+++ b/src/lua.hpp
@@ -2,7 +2,7 @@
 
 extern "C" {
 #include "lauxlib.h"
-#include "lib3rd.h"
+#include "lua_extensions.h"
 #include "lua.h"
 #include "luajit.h"
 #include "lualib.h"

--- a/src/lua_extensions.h
+++ b/src/lua_extensions.h
@@ -1,5 +1,7 @@
 #include "luaconf.h"
+
 typedef struct lua_State lua_State;
+
 LUALIB_API int(luaopen_cjson)(lua_State *L);
 LUALIB_API int(luaopen_struct)(lua_State *L);
 LUALIB_API int(luaopen_cmsgpack)(lua_State *L);


### PR DESCRIPTION
Since lib3rd.h will be imported for the global header indexing in kvrocks, we can give it a more concrete name.